### PR TITLE
Migrated to API v2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,5 @@
 {
-  "manifest_version": "2",
-  "api_version": "1",
+  "required_api_version": "^2.0.0",
   "name": "Notes",
   "description": "Notes extension",
   "developer_name": "Barak Tawily",

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,10 @@
+[
+  {
+    "required_api_version": "^1.0.0",
+    "commit": "api-v1-release"
+  },
+  {
+    "required_api_version": "^2.0.0",
+    "commit": "master"
+  }
+]


### PR DESCRIPTION
I've added branch `api-v1-release`, as per ulaunchers migration guide. It's identical to the previous master (API v1).
Please do a `git fetch git@github.com:therj/ulauncher-netlify.git api-v1-release`.

